### PR TITLE
fix issue - ender does not support multiple sources in packageJSON.main

### DIFF
--- a/lib/source-package.js
+++ b/lib/source-package.js
@@ -96,7 +96,7 @@ var path              = require('path')
           this.packageJSON = packageJSON
 
           if (!this.packageJSON.main) this.packageJSON.main = './index.js'
-          if (!this.packageJSON.main.match(/\.js$/)) this.packageJSON.main += '.js'
+          if (typeof this.packageJSON.main == "string" &&  !this.packageJSON.main.match(/\.js$/)) this.packageJSON.main += '.js'
 
           // custom hasher function for async.memoize so we have a single key, default will use
           // first arg (callback) as hash key which won't work


### PR DESCRIPTION
This is built-in feature in old version of enderjs
